### PR TITLE
build: dockerfile with cicd

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+.git
+.gitignore
+.svelte-kit
+.env
+.env.local
+.env.production
+.vscode
+dist
+*.md
+.eslintrc*
+.prettierrc*
+Dockerfile
+.dockerignore

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,69 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build-and-push:
+    if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .bun
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Set Docker tag
+        id: docker_tag
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/dev" ]]; then
+            echo "TAG=latest-dev" >> $GITHUB_ENV
+          else
+            echo "TAG=latest" >> $GITHUB_ENV
+          fi
+
+      - name: Build Docker image
+        run: |
+          docker build . -t bunnybunbun37204/cusw-dashboard:${{ env.TAG }}
+
+      - name: Push Docker image to Docker Hub
+        run: docker push bunnybunbun37204/cusw-dashboard:${{ env.TAG }}
+
+  code-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 'latest'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build application
+        run: bun run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Use the official Bun image as base
+FROM oven/bun:latest AS base
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package.json bun.lock* ./
+
+# Install dependencies
+RUN bun install --frozen-lockfile
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN bun run build
+
+# Production stage
+FROM oven/bun:latest-slim AS production
+
+# Set working directory
+WORKDIR /app
+
+# Copy built application and package files
+COPY --from=base /app/build ./build
+COPY --from=base /app/package.json ./
+COPY --from=base /app/node_modules ./node_modules
+
+# Expose port 5432
+EXPOSE 5431
+
+# Set environment variables
+ENV NODE_ENV=production
+ENV PORT=5431
+ENV HOST=0.0.0.0
+
+# Start the application
+CMD ["bun", "run", "start"]

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
 	"name": "cusw-dashboard",
-	"version": "0.0.1",
+	"version": "0.0.1",	
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run prepack",
 		"preview": "vite preview",
+		"start": "vite preview --host 0.0.0.0 --port 5431",
 		"prepare": "svelte-kit sync || echo ''",
 		"prepack": "svelte-kit sync && svelte-package && publint",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
This pull request introduces Docker support for the project, including a Dockerfile, a `.dockerignore` file, and a GitHub Actions workflow for building and pushing Docker images. Additionally, it modifies the `package.json` to add a new `start` script for running the application in production mode. Below are the most important changes grouped by theme:

### Docker Support:

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R14): Added a `.dockerignore` file to exclude unnecessary files and directories from the Docker build context, such as `node_modules`, `.git`, `.env`, and others.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R39): Created a multi-stage Dockerfile using the Bun runtime to install dependencies, build the application, and set up a production environment. Exposes port `5431` and defines environment variables for production.

### CI/CD Integration:

* [`.github/workflows/docker-build-push.yml`](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10R1-R69): Added a GitHub Actions workflow to automate building and pushing Docker images to Docker Hub on pushes to `dev` and `main` branches, as well as pull requests. Includes caching for Bun dependencies and conditional tagging of Docker images.

### Application Configuration:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R8): Added a `start` script to run the application in production mode using Vite on host `0.0.0.0` and port `5431`.